### PR TITLE
Fix: readonly option setting was not being saved

### DIFF
--- a/inc/wpdp_settings.php
+++ b/inc/wpdp_settings.php
@@ -23,6 +23,7 @@
 			
 				update_option( 'wp_datepicker', sanitize_text_field($_POST['wp_datepicker']));
 				update_option( 'wp_datepicker_language', sanitize_text_field($_POST['wp_datepicker_language']));
+				update_option( 'wp_datepicker_readonly', sanitize_text_field($_POST['wp_datepicker_readonly']));
 			}
 			
 		


### PR DESCRIPTION
The **Make datepicker field editable or readonly?** options setting was not being saved.

This repo doesn't seem to be caught up to the actual plugin version in the WordPress repo but this patch applies to the latest version of the code as well. Just a one line addition to save the setting.

